### PR TITLE
Be selective about the route at Fastly

### DIFF
--- a/lib/ohai/plugins/linux/network.rb
+++ b/lib/ohai/plugins/linux/network.rb
@@ -217,7 +217,7 @@ Ohai.plugin(:Network) do
         #    the routing table source field.
         # 3) and since we're at it, let's populate some :routes attributes
         # (going to do that for both inet and inet6 addresses)
-        so = shell_out("ip -o -f #{family[:name]} route show")
+        so = shell_out("ip -o -f #{family[:name]} route show 0/0")
         so.stdout.lines do |line|
           line.strip!
           Ohai::Log.debug("Parsing #{line}")


### PR DESCRIPTION
We want to only collect the default route here or Ohai will collect
all 2millions of routes from our host's routing table.

XXX: Need improvement for v6 default routes
